### PR TITLE
Revert `vmec2rpz` to Return the Toroidal Angle

### DIFF
--- a/src/pystell/read_vmec.py
+++ b/src/pystell/read_vmec.py
@@ -895,7 +895,7 @@ class VMECData:
         r = sum(self.rinterp * np.cos(angle))
         z = sum(self.zinterp * np.sin(angle))
 
-        return r, z
+        return r, zeta, z
 
     def vmec2xyz(self, s, theta, zeta):
         """


### PR DESCRIPTION
Changes the `return` statement of `VMECData.vmec2rpz` in `read_vmec.py` such that it returns the toroidal angle `zeta` again.

Closes #7.