### PR TITLE
Simpler test for mayavi package

### DIFF
--- a/src/pystell/read_vmec.py
+++ b/src/pystell/read_vmec.py
@@ -10,7 +10,6 @@ displaying plots, or exporting data.
 from netCDF4 import Dataset
 import numpy as np
 import matplotlib.pyplot as plt
-import imp
 from matplotlib import cm
 from scipy.optimize import fsolve
 import scipy.integrate as integrate
@@ -19,9 +18,8 @@ from scipy.optimize import minimize
 import logging
 
 try:
-    imp.find_module("mayavi")
-    use_mayavi = True
     from mayavi import mlab
+    use_mayavi = True
     import vtk
 except ImportError:
     use_mayavi = False


### PR DESCRIPTION
Rather than using `imp` to test for existing of package just try to import it.

Fixes #11 

The only place the imported `imp` module was used was to try to find the `mayavi` module, and this was done within a `try/except` block.  It should be possible to just try to import the module and test that in a `try/except` block.

I don't have all the modules to test whether this works, so I'll rely on someone else to confirm?